### PR TITLE
feat: engage in convos

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -21,6 +21,7 @@
     "ai": "^4.0.22",
     "bentocache": "1.0.0-beta.9",
     "database": "workspace:^",
+    "date-fns": "^4.1.0",
     "discord.js": "^14.17.3",
     "dotenv": "^16.4.7",
     "fastify": "^5.2.0",

--- a/agent/src/inngest.ts
+++ b/agent/src/inngest.ts
@@ -44,6 +44,11 @@ const baseExecuteTweetEvent = z.object({
   tweetUrl: z.string(),
 });
 
+const processInteractionTweetEvent = z.object({
+  name: z.literal('tweet.process.interaction'),
+  data: TweetResponse,
+}) satisfies LiteralZodEventSchema;
+
 const executeTweetEvent = z.object({
   name: z.literal('tweet.execute'),
   data: z.union([
@@ -60,5 +65,9 @@ const executeTweetEvent = z.object({
 // Create a client to send and receive events
 export const inngest = new Inngest({
   id: '@dogexbt/agent',
-  schemas: new EventSchemas().fromZod([processTweetEvent, executeTweetEvent]),
+  schemas: new EventSchemas().fromZod([
+    processTweetEvent,
+    executeTweetEvent,
+    processInteractionTweetEvent,
+  ]),
 });

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -7,6 +7,7 @@ import { executeTweets } from './twitter/execute';
 import { DISCORD_TOKEN } from './const';
 import { discordClient } from './discord/client';
 import { reportFailureToDiscord } from './discord/action';
+import { ingestInteractionTweets } from './twitter/ingest-interact';
 
 const fastify = Fastify();
 
@@ -14,7 +15,12 @@ fastify.route({
   method: ['GET', 'POST', 'PUT'],
   handler: serve({
     client: inngest,
-    functions: [ingestTweets, processTweets, executeTweets],
+    functions: [
+      ingestTweets,
+      processTweets,
+      executeTweets,
+      ingestInteractionTweets,
+    ],
   }),
   url: '/api/inngest',
 });

--- a/agent/src/server.ts
+++ b/agent/src/server.ts
@@ -7,7 +7,8 @@ import { executeTweets } from './twitter/execute';
 import { DISCORD_TOKEN } from './const';
 import { discordClient } from './discord/client';
 import { reportFailureToDiscord } from './discord/action';
-import { ingestInteractionTweets } from './twitter/ingest-interact';
+import { ingestInteractionTweets } from './twitter/ingest-interaction';
+import { processInteractionTweets } from './twitter/process-interactions';
 
 const fastify = Fastify();
 
@@ -20,6 +21,7 @@ fastify.route({
       processTweets,
       executeTweets,
       ingestInteractionTweets,
+      processInteractionTweets,
     ],
   }),
   url: '/api/inngest',

--- a/agent/src/twitter/helpers.ts
+++ b/agent/src/twitter/helpers.ts
@@ -12,12 +12,11 @@ import { openai } from '@ai-sdk/openai';
 // Ada V2 31.4% vs 54.9% large
 const embeddingModel = openai.textEmbeddingModel('text-embedding-3-small');
 
-const API = new URL(TWITTER_API_BASE_URL);
-
 const GetTweetResponse = z.object({
   tweets: z.array(TweetResponse),
 });
 
+const API = new URL(TWITTER_API_BASE_URL);
 export async function getTweet({ id }: { id: string }) {
   API.pathname = '/twitter/tweets';
   return bento.getOrSet(`/tweet/${id}`, async () => {
@@ -64,3 +63,9 @@ export const generateEmbeddings = async (
   });
   return embeddings;
 };
+
+export const SearchResultResponseSchema = z.object({
+  tweets: z.array(TweetResponse),
+  has_next_page: z.boolean(),
+  next_cursor: z.string().nullable(),
+});

--- a/agent/src/twitter/ingest-interact.ts
+++ b/agent/src/twitter/ingest-interact.ts
@@ -1,0 +1,119 @@
+import { TWITTER_API_BASE_URL, TWITTER_API_KEY } from '../const';
+import { inngest } from '../inngest';
+import { z } from 'zod';
+import { chunk } from 'lodash-es';
+import { reportFailureToDiscord } from '../discord/action';
+import { SearchResultResponseSchema } from './helpers';
+import { getUnixTime, subMinutes } from 'date-fns';
+
+const API = new URL(TWITTER_API_BASE_URL);
+API.pathname = '/twitter/list/tweets';
+
+async function fetchTweetsFromList({
+  id,
+  window,
+}: {
+  id: string;
+  window: number;
+}) {
+  const current = new Date();
+  API.searchParams.set('listId', id);
+  API.searchParams.set('includeReplies', 'false');
+  API.searchParams.set(
+    'sinceTime',
+    getUnixTime(subMinutes(current, window)).toString(),
+  );
+  API.searchParams.set('untilTime', getUnixTime(current).toString());
+
+  let tweets: z.infer<typeof SearchResultResponseSchema>['tweets'] = [];
+  let cursor = '';
+  API.searchParams.set('cursor', cursor);
+
+  do {
+    const response = await fetch(API.toString(), {
+      method: 'GET',
+      headers: {
+        'X-API-Key': TWITTER_API_KEY,
+      },
+    });
+    const data = await response.json();
+
+    const result = await SearchResultResponseSchema.safeParseAsync(data);
+
+    if (result.success === false) {
+      throw new Error(result.error.errors.join(', '));
+    }
+
+    tweets = tweets.concat(result.data.tweets);
+    cursor = result.data.next_cursor || '';
+    API.searchParams.set('cursor', cursor);
+
+    // If there are no more tweets to fetch, break out of the loop
+    if (!result.data.has_next_page) {
+      break;
+    }
+  } while (cursor);
+
+  return tweets;
+}
+
+export const ingestInteractionTweets = inngest.createFunction(
+  {
+    id: 'ingest-interaction-tweets',
+    onFailure: async ({ error }) => {
+      const errorMessage = error.message;
+      await reportFailureToDiscord({
+        message: `[ingest-interaction-tweets]: ${errorMessage}`,
+      });
+    },
+  },
+  // Runs every 10 minutes
+  { cron: '*/10 * * * *' },
+  async () => {
+    const [congress119Senators, dogeAiEngager, houseMembers] =
+      await Promise.all([
+        // https://x.com/i/lists/1882132360512061660
+        fetchTweetsFromList({
+          window: 12,
+          id: '1882132360512061660',
+        }),
+        // https://x.com/i/lists/1883919897194815632
+        fetchTweetsFromList({
+          window: 12,
+          id: '1883919897194815632',
+        }),
+        // https://x.com/i/lists/225745413
+        fetchTweetsFromList({
+          window: 12,
+          id: '225745413',
+        }),
+      ]);
+
+    const tweets = congress119Senators.concat(dogeAiEngager, houseMembers);
+
+    /**
+     * There is a limit of 512KB for batching events. To avoid hitting this limit, we chunk the tweets
+     * https://www.inngest.com/docs/events#sending-multiple-events-at-once
+     */
+    const chunkTweets = chunk(tweets, 5);
+    console.log(
+      `Chunked ${tweets.length} tweets into ${chunkTweets.length} chunks`,
+    );
+
+    // chunkTweets.forEach(async chunk => {
+    //   const inngestSent = await inngest.send(
+    //     chunk.map(tweet => ({
+    //       name: 'tweet.process',
+    //       data: tweet,
+    //       id: tweet.id,
+    //     })),
+    //   );
+
+    //   console.log(`Sent ${inngestSent.ids.length} tweets to inngest`);
+    // });
+
+    // return {
+    //   message: `Sent ${tweets.length} tweets to inngest`,
+    // };
+  },
+);

--- a/agent/src/twitter/ingest-interaction.ts
+++ b/agent/src/twitter/ingest-interaction.ts
@@ -89,7 +89,11 @@ export const ingestInteractionTweets = inngest.createFunction(
         }),
       ]);
 
-    const tweets = congress119Senators.concat(dogeAiEngager, houseMembers);
+    const tweets = congress119Senators
+      .concat(dogeAiEngager, houseMembers)
+      // make sure to filter out any replies - for now
+      // even though we set `includeReplies` to false in the API call above it still returns replies sometimes.
+      .filter(t => t.isReply === false);
 
     /**
      * There is a limit of 512KB for batching events. To avoid hitting this limit, we chunk the tweets
@@ -100,20 +104,20 @@ export const ingestInteractionTweets = inngest.createFunction(
       `Chunked ${tweets.length} tweets into ${chunkTweets.length} chunks`,
     );
 
-    // chunkTweets.forEach(async chunk => {
-    //   const inngestSent = await inngest.send(
-    //     chunk.map(tweet => ({
-    //       name: 'tweet.process',
-    //       data: tweet,
-    //       id: tweet.id,
-    //     })),
-    //   );
+    chunkTweets.forEach(async chunk => {
+      const inngestSent = await inngest.send(
+        chunk.map(tweet => ({
+          name: 'tweet.process.interaction',
+          data: tweet,
+          id: tweet.id,
+        })),
+      );
 
-    //   console.log(`Sent ${inngestSent.ids.length} tweets to inngest`);
-    // });
+      console.log(`Sent ${inngestSent.ids.length} tweets to inngest`);
+    });
 
-    // return {
-    //   message: `Sent ${tweets.length} tweets to inngest`,
-    // };
+    return {
+      message: `Sent ${tweets.length} tweets to inngest`,
+    };
   },
 );

--- a/agent/src/twitter/ingest.ts
+++ b/agent/src/twitter/ingest.ts
@@ -7,15 +7,10 @@ import { inngest, TweetResponse } from '../inngest';
 import { z } from 'zod';
 import { chunk } from 'lodash-es';
 import { reportFailureToDiscord } from '../discord/action';
+import { SearchResultResponseSchema } from './helpers';
 
 const API = new URL(TWITTER_API_BASE_URL);
 API.pathname = '/twitter/tweet/advanced_search';
-
-const SearchResultResponseSchema = z.object({
-  tweets: z.array(TweetResponse),
-  has_next_page: z.boolean(),
-  next_cursor: z.string().nullable(),
-});
 
 /**
  * Fetches tweets from the Twitter API and queues them for processing.

--- a/agent/src/twitter/process-interactions.ts
+++ b/agent/src/twitter/process-interactions.ts
@@ -1,0 +1,63 @@
+import { inngest } from '../inngest.ts';
+import { NonRetriableError } from 'inngest';
+import { openai } from '@ai-sdk/openai';
+import { generateText } from 'ai';
+import { rejectedTweet, reportFailureToDiscord } from '../discord/action.ts';
+import { INTERACTION_ENGAGEMENT_DECISION_PROMPT } from './prompts.ts';
+
+export const processInteractionTweets = inngest.createFunction(
+  {
+    id: 'process-interaction-tweets',
+    onFailure: async ({ event, error }) => {
+      const id = event?.data?.event?.data?.id;
+      const url = event?.data?.event?.data?.url;
+
+      if (!id || !url) {
+        console.error('Failed to extract tweet ID or URL from event data');
+        await reportFailureToDiscord({
+          message: `[process-interaction-tweets]: unable to extract tweet ID or URL from event data. Run id: ${event.data.run_id}`,
+        });
+        return;
+      }
+
+      await rejectedTweet({
+        tweetId: id,
+        tweetUrl: url,
+        reason: error.message,
+      });
+    },
+    throttle: {
+      limit: 10,
+      period: '1m',
+    },
+  },
+  { event: 'tweet.process.interaction' },
+  async ({ event, step }) => {
+    const shouldEngage = await step.run('should-engage', async () => {
+      const result = await generateText({
+        model: openai('gpt-4o'),
+        temperature: 0,
+        messages: [
+          { role: 'system', content: INTERACTION_ENGAGEMENT_DECISION_PROMPT },
+          {
+            role: 'user',
+            content: `Now give me a determination for this tweet: ${event.data.text}`,
+          },
+        ],
+      });
+
+      const decision = result.text.toLowerCase().trim().replace('.', ' ');
+
+      return decision === 'engage' ? true : result.text;
+    });
+
+    if (shouldEngage === true) {
+      // TODO: integrate with the execute-tweet function
+      return;
+    }
+
+    if (typeof shouldEngage === 'string') {
+      throw new NonRetriableError(shouldEngage);
+    }
+  },
+);

--- a/agent/src/twitter/prompts.ts
+++ b/agent/src/twitter/prompts.ts
@@ -141,3 +141,22 @@ export const QUESTION_EXTRACTOR_SYSTEM_PROMPT = `You are an advanced text analys
 export const ENGAGEMENT_DECISION_PROMPT = `Your role is to determine whether a reply to a tweet warrants engagement ("ENGAGE") or should be ignored ("IGNORE"). Your responses must consist of only one word: either "ENGAGE" or "IGNORE." Do not include any analysis, commentary, or reasoning—just output the decision. To decide, analyze replies based on three criteria: connection to context, presence of a clear question, and good-faith indicators. For example, if the reply directly relates to the tweet’s topic and includes a question demonstrating curiosity or seeking clarification, respond with "ENGAGE." Otherwise, respond with "IGNORE." Examples of replies to engage with include: Tweet: "The government is wasting $50 million on forensic DNA gadgets while ignoring community crime prevention programs," Reply: "Why spend $50 million on gadgets instead of reducing crime at the root?" → ENGAGE, Reply: "Can the government explain how this spending benefits public safety?" → ENGAGE; Tweet: "Another $25M for DNA equipment grants. Couldn’t that money fund something more impactful?" Reply: "How do DNA equipment grants actually reduce crime rates?" → ENGAGE, Reply: "Does anyone know how much of this spending goes toward administrative costs?" → ENGAGE. Examples of replies to ignore include: Reply: "Love your project! 🚀 Let’s connect!" → IGNORE, Reply: "Cool post, man! Keep it up!" → IGNORE, Reply: "@elonmusk" → IGNORE, Reply: "This is interesting!" → IGNORE. Analyze tone for good-faith indicators—spam-like or vague replies, such as "Let’s collaborate!" or "Nice work," should always be ignored. For borderline cases, such as "I like parks more than war," use the absence of a clear question to decide on "IGNORE." In all cases, output only "ENGAGE" or "IGNORE," ensuring clarity, brevity, and precision.`;
 
 export const EXTRACT_BILL_TITLE_PROMPT = `You are an AI specialized in analyzing tweets related to U.S. Congressional bills. Given a tweet, extract the official title of the bill mentioned. If multiple bills are referenced, list all their titles. If no bill is mentioned, respond with 'NO_TITLE_FOUND.' Return only the title(s) without additional commentary.`;
+
+export const INTERACTION_ENGAGEMENT_DECISION_PROMPT = `Evaluate a tweet's relevance based on specific topics: government contracts, defense procurement, legislation, funding, public policy decisions, foreign aid, national security, wildlife protection, Real estate, Immigration policy, gun control, environmental governance and influential leaders and their roles in driving change.
+
+### Steps:
+1. **Identify Content**: Check for mentions of government contracts, legislation, defense, or public policy.
+2. **Relevance Check**: Look for key influencers, such as prominent senators, and assess the validity of statements or retweets.
+3. **Criteria for Engagement**:
+- If the tweet mentions defense procurement, key leaders, or in-depth analyses, return "ENGAGE."
+- If a prominent Democratic senator discusses the negative impact of foreign aid reduction, return "ENGAGE," regardless of supporting evidence or analysis.
+- If a prominent Democratic senator makes blanket statements about savings or tax cuts without supporting evidence, return "ENGAGE".
+- If the tweet mentions a specific piece of legislation, return "ENGAGE"
+- if a prominent Republican senator retweets an analysis of overspending, return "ENGAGE"
+- If the tweet criticizes accuses actions being illegal, undemocratic, or paving the way for corruption, return "ENGAGE"
+- If the tweet reflects on the memory of all those lost, return "ENGAGE"
+
+### Output:
+- Return "ENGAGE" if relevant.
+- If not, provide a short reason.
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       database:
         specifier: workspace:^
         version: link:../database
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       discord.js:
         specifier: ^14.17.3
         version: 14.17.3
@@ -1923,6 +1926,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -5604,6 +5610,8 @@ snapshots:
       call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   debug@2.6.9:
     dependencies:


### PR DESCRIPTION
Setup the crawler for a X lists which are some notable accounts we want the bot to engage with. It will run every 10 mins and cover the last 12min window (account for any processing delays). This is a good start, can make the time window longer but I feel it is good for starters.

Once we have a tweet, it is fed to processing job which decides the engagement criteria. See `INTERACTION_ENGAGEMENT_DECISION_PROMPT`.

Once this is merged need to integrate with #51 