### PR TITLE
feat: for keyword search on bills only focus on active

### DIFF
--- a/agent/src/const.ts
+++ b/agent/src/const.ts
@@ -110,3 +110,4 @@ export const DISCORD_LOCAL_TWEETS_CHANNEL_ID = (() => {
 })();
 export const TEMPERATURE = 0;
 export const SEED = 69;
+export const ACTIVE_CONGRESS = 119;

--- a/agent/src/twitter/execute-interaction.ts
+++ b/agent/src/twitter/execute-interaction.ts
@@ -50,8 +50,12 @@ import { logger, WithLogger } from '../logger.ts';
 /**
  * Given some text try to find the specific bill.
  *
- * If you do not get a bill title
- * we are out of luck and safely error
+ * It works in the following precedence:
+ * 1. If a bill number is found we search that, narrow down to relevancy to the conversation and return most relevant.
+ *    We do not do active congress here because someone could be asking a question for past congress bill for some reference
+ *    So this approach allows us to make sure we don't rule those out.
+ * 2. If we have bill titles we search for those and return the first one.
+ * 3. If we have keywords we search we focus on the current congress and return the most relevant.
  */
 export async function getReasonBillContext(
   {

--- a/agent/src/twitter/execute-interaction.ts
+++ b/agent/src/twitter/execute-interaction.ts
@@ -1,4 +1,10 @@
-import { IS_PROD, REJECTION_REASON, SEED, TEMPERATURE } from '../const';
+import {
+  ACTIVE_CONGRESS,
+  IS_PROD,
+  REJECTION_REASON,
+  SEED,
+  TEMPERATURE,
+} from '../const';
 import { inngest } from '../inngest';
 import { NonRetriableError } from 'inngest';
 import * as crypto from 'node:crypto';
@@ -256,6 +262,7 @@ Always return a "billId", selecting the most recent bill if no contextual match 
           and(
             sql`vector_distance_cos(${billVector.vector}, vector32(${termEmbeddingString})) < ${THRESHOLD}`,
             isNotNull(billVector.bill),
+            eq(billDbSchema.congress, ACTIVE_CONGRESS),
           ),
         )
         .orderBy(
@@ -343,6 +350,7 @@ Always return a "billId", selecting the most recent bill if no contextual match 
           const filters = [
             sql`vector_distance_cos(${billVector.vector}, vector32(${embeddingArrayString})) < ${THRESHOLD}`,
             isNotNull(billVector.bill),
+            eq(billDbSchema.congress, ACTIVE_CONGRESS),
           ];
 
           if (relatedBills?.billIds) {


### PR DESCRIPTION
### Before

When doing keyword search we were searching everyhting. The issue this creates is it can find bills from past congress which can be considered bad because we want to focus on current day events. Those won't have any impact

### New

Keyword search narrow down to active congress this way we ensure only relevant bills from current administration are discussed.
