### PR TITLE
fix: non retriable error on twitter send faliures

### DIFF
--- a/agent/src/twitter/execute-interaction.ts
+++ b/agent/src/twitter/execute-interaction.ts
@@ -311,20 +311,25 @@ export const executeInteractionTweets = inngest.createFunction(
             };
           }
 
-          const resp = await twitterClient.v2.tweet(reply.response, {
-            reply: {
-              in_reply_to_tweet_id: tweetToActionOn.id,
-            },
-          });
-          log.info(resp, 'tweet sent');
-          tweetsPublished.inc({
-            action: event.data.action,
-            method: 'execute-interaction-tweets',
-          });
+          try {
+            const resp = await twitterClient.v2.tweet(reply.response, {
+              reply: {
+                in_reply_to_tweet_id: tweetToActionOn.id,
+              },
+            });
+            log.info(resp, 'tweet sent');
+            tweetsPublished.inc({
+              action: event.data.action,
+              method: 'execute-interaction-tweets',
+            });
 
-          return {
-            id: resp.data.data.id,
-          };
+            return {
+              id: resp.data.data.id,
+            };
+          } catch (error) {
+            log.error({ error }, 'Failed to send tweet');
+            throw new NonRetriableError(error as any);
+          }
         });
 
         await step.run('notify-discord', async () => {

--- a/agent/src/twitter/execute.ts
+++ b/agent/src/twitter/execute.ts
@@ -456,20 +456,25 @@ export const executeTweets = inngest.createFunction(
         };
       }
 
-      const resp = await twitterClient.v2.tweet(reply.text, {
-        reply: {
-          in_reply_to_tweet_id: tweetToActionOn.id,
-        },
-      });
-      log.info(resp, 'tweet sent');
-      tweetsPublished.inc({
-        action: event.data.action,
-        method: 'execute-tweets',
-      });
+      try {
+        const resp = await twitterClient.v2.tweet(reply.text, {
+          reply: {
+            in_reply_to_tweet_id: tweetToActionOn.id,
+          },
+        });
+        log.info(resp, 'tweet sent');
+        tweetsPublished.inc({
+          action: event.data.action,
+          method: 'execute-tweets',
+        });
 
-      return {
-        id: resp.data.data.id,
-      };
+        return {
+          id: resp.data.data.id,
+        };
+      } catch (error) {
+        log.error({ error }, 'failed to send tweet');
+        throw new NonRetriableError(error as any);
+      }
     });
 
     await step.run('notify-discord', async () => {


### PR DESCRIPTION
Making it a `NonRetriable` error will ensure the `step` is not retried.

closes https://github.com/saihaj/DOGE-AI/issues/128