### PR TITLE
feat: only generate short if we will return

### DIFF
--- a/agent/src/twitter/execute-interaction.ts
+++ b/agent/src/twitter/execute-interaction.ts
@@ -292,6 +292,18 @@ export const executeInteractionTweets = inngest.createFunction(
           const finalAnswer = await getShortResponse({ topic: responseLong });
           log.info({ response: finalAnswer }, 'generated short');
 
+          // some times claude safety kicks in and we get a NO
+          if (finalAnswer.toLowerCase().startsWith('no')) {
+            log.warn({}, 'claude safety kicked in. returning long');
+            return {
+              // Implicitly we are returning the long output so others can be ignored
+              longOutput: '',
+              refinedOutput: '',
+              metadata,
+              response: responseLongFormatted,
+            };
+          }
+
           return {
             longOutput: responseLongFormatted,
             refinedOutput: finalAnswer,


### PR DESCRIPTION
80% times we don't use the short output. It was great early on to test but given we have much higher volumes we shouldn't waste time & compute if we are not going to use.