### PR TITLE
Add CRON Job for Daily Indexing of DOGE.gov URLs

### DIFF
--- a/crawler/src/ingest/index.ts
+++ b/crawler/src/ingest/index.ts
@@ -2,12 +2,14 @@ import { embedBill } from './embed-bill';
 import { processBill } from './process-bill';
 import { processDocument } from './process-document';
 import { processWebpage } from './process-web';
+import { scheduledScrape } from './scheduled-scrape';
 
 export const functions = [
   processBill,
   embedBill,
   processDocument,
   processWebpage,
+  scheduledScrape
 ];
 
 export { inngest } from './client';

--- a/crawler/src/ingest/scheduled-scrape.ts
+++ b/crawler/src/ingest/scheduled-scrape.ts
@@ -1,0 +1,48 @@
+import { inngest } from './client';
+
+export const scheduledScrape = inngest.createFunction(
+  { id: 'scheduled-scrape' },
+  { cron: '0 0 * * *' }, // Runs daily at midnight UTC
+  async ({ step }) => {
+    await step.sendEvent('send-scrape-events', [
+      {
+        name: 'web.imported',
+        data: {
+          url: 'https://doge.gov/savings',
+          actions: [
+            { selector: "//*[text()='Show All Agencies']", type: 'click' },
+            { selector: "//*[text()='View All Contracts']", type: 'click' },
+            { selector: "//*[text()='View All Grants']", type: 'click' },
+            { selector: "//*[text()='View All Leases']", type: 'click' },
+          ],
+        },
+      },
+      {
+        name: 'web.imported',
+        data: {
+          url: 'https://doge.gov/regulations',
+          actions: [
+            { type: 'click', selector: "//*[text()='Load More Agencies']" },
+            { type: 'wait', milliseconds: 500 },
+            { type: 'click', selector: "//*[text()='Load More Agencies']" },
+            { type: 'wait', milliseconds: 500 },
+            { type: 'click', selector: "//*[text()='Load More Agencies']" },
+            { type: 'wait', milliseconds: 500 },
+            { type: 'click', selector: "//*[text()='Load More Agencies']" },
+            { type: 'wait', milliseconds: 500 },
+            { type: 'click', selector: "//*[text()='Load More Agencies']" },
+            { type: 'wait', milliseconds: 500 },
+            { type: 'click', selector: "//*[text()='Load More Agencies']" },
+            { type: 'wait', milliseconds: 500 },
+          ],
+        },
+      },
+      {
+        name: 'web.imported',
+        data: {
+          url: 'https://doge.gov/spend',
+        },
+      },
+    ]);
+  }
+);

--- a/database/package.json
+++ b/database/package.json
@@ -7,7 +7,8 @@
   "types": "src/index.ts",
   "scripts": {
     "dev": "tsx --watch ./src/client.ts",
-    "generate": "drizzle-kit generate"
+    "generate": "drizzle-kit generate",
+    "push": "drizzle-kit push"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",


### PR DESCRIPTION
Closes #100

This PR adds a scheduled function using the Inngest client to crawl and index [DOGE.gov](http://doge.gov/) URLs. This replaces ingesting manually. The function is set to run at midnight via a CRON schedule and is registered with the Inngest index.

## Details
- Created a new Inngest function to automate the crawling of specified [DOGE.gov](http://doge.gov/) URLs.
- Scheduled it to run daily at midnight (CRON: `0 0  *`).

## Testing
- Verified functionality on a local Inngest server; the job runs as expected and indexes the URLs.

## Next Steps
- Confirm the CRON job triggers in the production Inngest environment after deployment.