### PR TITLE
feat: only crawl bill if it changed in last week

### DIFF
--- a/crawler/package.json
+++ b/crawler/package.json
@@ -31,6 +31,7 @@
     "@mendable/firecrawl-js": "^1.17.0",
     "ai": "^4.3.2",
     "database": "workspace:*",
+    "date-fns": "^4.1.0",
     "fast-content-type-parse": "^2.0.1",
     "fastify": "^5.3.1",
     "he": "^1.2.0",

--- a/crawler/src/ingest/process-bill.ts
+++ b/crawler/src/ingest/process-bill.ts
@@ -115,25 +115,6 @@ export const processBill = inngest.createFunction(
   async ({ event, step }) => {
     const bill = event.data;
 
-    await step.run('check-bill-exists', async () => {
-      const b = await db.query.bill.findFirst({
-        where: and(
-          eq(billDbSchema.congress, bill.congress),
-          eq(billDbSchema.number, Number(bill.number)),
-          eq(billDbSchema.type, bill.type),
-        ),
-        columns: {
-          id: true,
-        },
-      });
-
-      if (b) {
-        throw new NonRetriableError('Bill already exists', {
-          cause: `Bill ${bill.congress} ${bill.number} ${bill.type} already exists`,
-        });
-      }
-    });
-
     const info = await step.run('get-bill-info', async () => {
       const url = new URL(bill.url);
       url.pathname = url.pathname + '/text';

--- a/crawler/src/scripts/enqueue-bill.ts
+++ b/crawler/src/scripts/enqueue-bill.ts
@@ -2,6 +2,7 @@ import { inngest } from '../ingest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { differenceInDays } from 'date-fns';
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
@@ -20,10 +21,21 @@ async function main() {
     const contents = JSON.parse(data);
 
     console.log(`Sending ${contents.bills.length} bills to Inngest...`);
+    // We look at bills that have changed in the last 8 days since we are running this each week
+    const todayDate = new Date();
+
+    // @ts-expect-error - gotta type this better
+    const filteredBills = contents.bills.filter(bill => {
+      const updateDateIncludingText = new Date(bill.updateDateIncludingText);
+      const diff = differenceInDays(todayDate, updateDateIncludingText);
+      return diff <= 8;
+    });
+
+    console.log(`Filtered ${filteredBills.length} bills to send to Inngest...`);
 
     const ing = await inngest.send(
       // @ts-expect-error - gotta type this better
-      contents.bills.map(bill => ({
+      filteredBills.bills.map(bill => ({
         name: 'bill.imported',
         id: `${bill.congress}-${bill.originChamberCode.toLowerCase()}-${bill.number}`,
         data: bill,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       database:
         specifier: workspace:*
         version: link:../database
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       fast-content-type-parse:
         specifier: ^2.0.1
         version: 2.0.1
@@ -9355,7 +9358,7 @@ snapshots:
       '@typescript-eslint/parser': 8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.4(eslint@9.18.0(jiti@2.4.2))
@@ -9395,7 +9398,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -9427,14 +9430,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -9460,7 +9463,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10210,7 +10213,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.7.9(debug@4.4.0))
+      retry-axios: 2.6.0(axios@1.7.9)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -11902,7 +11905,7 @@ snapshots:
 
   ret@0.5.0: {}
 
-  retry-axios@2.6.0(axios@1.7.9(debug@4.4.0)):
+  retry-axios@2.6.0(axios@1.7.9):
     dependencies:
       axios: 1.7.9(debug@4.4.0)
 


### PR DESCRIPTION
a bill text can update or bill action can update. So better is to look at when it was last updated then only enqueue to process it. This way we can make sure we have up to date and only include the bills that make sense to be included. 

A week (8 days as buffer) make sense since we run this every week.